### PR TITLE
numGraphemeClustersで文字列の長さを取得するように変更

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,5 +1,6 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
+import "@stdlib/string-num-grapheme-clusters"
 import "controllers"
 import "./character_counter"
 

--- a/app/javascript/character_counter.js
+++ b/app/javascript/character_counter.js
@@ -16,7 +16,7 @@ var CharacterCounter = CharacterCounter || {};
 CharacterCounter.initialize = function (textInput) {
   var updateTarget = function (textInput) {
     var text = textInput.value;
-    var length = [...text].length;
+    var length = numGraphemeClusters(text);
     var targets = document.querySelectorAll(textInput.dataset.target);
     targets.forEach(function (target) {
       target.textContent = length.toString();

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -5,3 +5,5 @@ pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
+pin "@stdlib/string-num-grapheme-clusters", to: "https://cdn.jsdelivr.net/npm/@stdlib/string-num-grapheme-clusters@0.0.9/lib/index.js"
+

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -5,5 +5,4 @@ pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
-pin "@stdlib/string-num-grapheme-clusters", to: "https://cdn.jsdelivr.net/npm/@stdlib/string-num-grapheme-clusters@0.0.9/lib/index.js"
-
+pin "@stdlib/string-num-grapheme-clusters", to: "https://cdn.jsdelivr.net/gh/stdlib-js/string-num-grapheme-clusters@umd/browser.js"


### PR DESCRIPTION
numGraphemeClustersを使って、書記素クラスタで文字列の長さを取得するように変更します。

![image](https://user-images.githubusercontent.com/2942348/192123346-25e75e19-e4d4-4798-90d3-3ca7b6901fb6.png)


# 参照
https://github.com/stdlib-js/string-num-grapheme-clusters